### PR TITLE
Verified the ict_v361 PCB

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Eagle PCB for v2-v5 of "my" version of the ICT hab board
 This pcb is made and setup for sw versions v2-v5 of the the ict code
 
 ict_v361-xs // using the QFN/MLF version of the 328 - Verified working                                                                                
-ict_v361 // using the TQFP version of the 328 - untested
+ict_v361 // using the TQFP version of the 328 - Verified working by Simonas LY2EN (@kareiva)


### PR DESCRIPTION
Ordered a handful of PCB's based on the untested ict_v361 design. 

Parts used:
* 3k9 resistors for pull-up
* 8MHz internal clock
* 27MHz TCXO
* ATGM336H GPS